### PR TITLE
Implement named pipe support

### DIFF
--- a/Debug/src/siri/net/subdir.mk
+++ b/Debug/src/siri/net/subdir.mk
@@ -10,7 +10,8 @@ C_SRCS += \
 ../src/siri/net/promise.c \
 ../src/siri/net/promises.c \
 ../src/siri/net/protocol.c \
-../src/siri/net/socket.c
+../src/siri/net/socket.c \
+../src/siri/net/pipe.c
 
 OBJS += \
 ./src/siri/net/bserver.o \
@@ -19,7 +20,8 @@ OBJS += \
 ./src/siri/net/promise.o \
 ./src/siri/net/promises.o \
 ./src/siri/net/protocol.o \
-./src/siri/net/socket.o
+./src/siri/net/socket.o \
+./src/siri/net/pipe.o
 
 C_DEPS += \
 ./src/siri/net/bserver.d \
@@ -28,7 +30,8 @@ C_DEPS += \
 ./src/siri/net/promise.d \
 ./src/siri/net/promises.d \
 ./src/siri/net/protocol.d \
-./src/siri/net/socket.d
+./src/siri/net/socket.d \
+./src/siri/net/pipe.d
 
 
 # Each subdirectory must supply rules for building sources it contributes
@@ -38,5 +41,3 @@ src/siri/net/%.o: ../src/siri/net/%.c
 	gcc -DDEBUG=1 -I../include -O0 -g3 -Wall -Wextra $(CPPFLAGS) $(CFLAGS) -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
-
-

--- a/Release/src/siri/net/subdir.mk
+++ b/Release/src/siri/net/subdir.mk
@@ -10,7 +10,8 @@ C_SRCS += \
 ../src/siri/net/promise.c \
 ../src/siri/net/promises.c \
 ../src/siri/net/protocol.c \
-../src/siri/net/socket.c
+../src/siri/net/socket.c \
+../src/siri/net/pipe.c
 
 OBJS += \
 ./src/siri/net/bserver.o \
@@ -19,7 +20,8 @@ OBJS += \
 ./src/siri/net/promise.o \
 ./src/siri/net/promises.o \
 ./src/siri/net/protocol.o \
-./src/siri/net/socket.o
+./src/siri/net/socket.o \
+./src/siri/net/pipe.o
 
 C_DEPS += \
 ./src/siri/net/bserver.d \
@@ -28,7 +30,8 @@ C_DEPS += \
 ./src/siri/net/promise.d \
 ./src/siri/net/promises.d \
 ./src/siri/net/protocol.d \
-./src/siri/net/socket.d
+./src/siri/net/socket.d \
+./src/siri/net/pipe.d
 
 
 # Each subdirectory must supply rules for building sources it contributes
@@ -38,5 +41,3 @@ src/siri/net/%.o: ../src/siri/net/%.c
 	gcc -I../include -O3 -Wall -Wextra $(CPPFLAGS) $(CFLAGS) -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
-
-

--- a/include/siri/cfg/cfg.h
+++ b/include/siri/cfg/cfg.h
@@ -23,6 +23,8 @@ typedef struct siri_cfg_s
     uint8_t shard_compression;
     char server_address[SIRI_CFG_MAX_LEN_ADDRESS];
     char default_db_path[SIRI_PATH_MAX];
+    uint8_t pipe_support;
+    char pipe_client_name[SIRI_PATH_MAX];
 } siri_cfg_t;
 
 void siri_cfg_init(siri_t * siri);

--- a/include/siri/net/clserver.h
+++ b/include/siri/net/clserver.h
@@ -12,9 +12,66 @@
 #pragma once
 
 #include <uv.h>
+#include <siri/net/pipe.h>
+#include <siri/net/socket.h>
 #include <siri/siri.h>
 
 typedef struct siri_s siri_t;
+
+#define sirinet_client_incref(client)                                          \
+switch ((client)->type)                                                        \
+{                                                                              \
+case UV_TCP:                                                                   \
+    sirinet_socket_incref(client);                                             \
+    break;                                                                     \
+case UV_NAMED_PIPE:                                                            \
+    sirinet_pipe_incref(client);                                               \
+    break;                                                                     \
+default:                                                                       \
+    break;                                                                     \
+}
+
+#define sirinet_client_decref(client)                                          \
+switch ((client)->type)                                                        \
+{                                                                              \
+case UV_TCP:                                                                   \
+    sirinet_socket_decref(client);                                             \
+    break;                                                                     \
+case UV_NAMED_PIPE:                                                            \
+    sirinet_pipe_decref(client);                                               \
+    break;                                                                     \
+default:                                                                       \
+    uv_close((uv_handle_t *) (client), NULL);                                  \
+    break;                                                                     \
+}
+
+#define CLIENT_SIRIDB(client, siridb)                                          \
+siridb_t * siridb = NULL;                                                      \
+switch ((client)->type)                                                        \
+{                                                                              \
+case UV_TCP:                                                                   \
+    siridb = ((sirinet_socket_t *) (client)->data)->siridb;                    \
+    break;                                                                     \
+case UV_NAMED_PIPE:                                                            \
+    siridb = ((sirinet_pipe_t *) (client)->data)->siridb;                      \
+    break;                                                                     \
+default:                                                                       \
+    break;                                                                     \
+}
+
+#define CLIENT_USER(client, user)                                              \
+siridb_user_t * user = NULL;                                                   \
+switch ((client)->type)                                                        \
+{                                                                              \
+case UV_TCP:                                                                   \
+    user = (siridb_user_t *) ((sirinet_socket_t *) (client)->data)->origin;    \
+    break;                                                                     \
+case UV_NAMED_PIPE:                                                            \
+    user = (siridb_user_t *) ((sirinet_pipe_t *) (client)->data)->origin;      \
+    break;                                                                     \
+default:                                                                       \
+    break;                                                                     \
+}
 
 int sirinet_clserver_init(siri_t * siri);
 

--- a/include/siri/net/pipe.h
+++ b/include/siri/net/pipe.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <uv.h>
+#include <siri/db/db.h>
+#include <siri/net/pkg.h>
+#include <xpath/xpath.h>
+
+#define PIPE_NAME_SZ SIRI_PATH_MAX
+#define RESET_BUF_SIZE 1048576  /*  1 MB        */
+
+typedef enum sirinet_pipe_tp
+{
+    PIPE_CLIENT,
+    PIPE_BACKEND
+} sirinet_pipe_tp_t;
+
+typedef struct siridb_s siridb_t;
+typedef struct siridb_user_s siridb_user_t;
+
+typedef void (* on_data_cb_t)(uv_stream_t * client, sirinet_pkg_t * pkg);
+typedef void (* on_free_cb_t)(uv_stream_t * client);
+
+typedef struct sirinet_pipe_s
+{
+    sirinet_pipe_tp_t tp;
+    uint32_t ref;
+    on_data_cb_t on_data;
+    on_free_cb_t on_free;
+    siridb_t * siridb;
+    void * origin;  /* can be a user, server or NULL */
+    char * buf;
+    size_t len;
+    size_t size;
+    uv_pipe_t pipe;
+} sirinet_pipe_t;
+
+uv_pipe_t * sirinet_pipe_new(
+        sirinet_pipe_tp_t tp,
+        on_data_cb_t cb_data,
+        on_free_cb_t cb_free);
+void sirinet_pipe_alloc_buffer(
+        uv_handle_t * handle,
+        size_t suggested_size,
+        uv_buf_t * buf);
+int sirinet_pipe_name(char * buffer, uv_stream_t * client);
+void sirinet_pipe_on_data(
+        uv_stream_t * client,
+        ssize_t nread,
+        const uv_buf_t * buf);
+void sirinet__pipe_free(uv_stream_t * client);
+
+#define sirinet_pipe_incref(client) \
+    ((sirinet_pipe_t *) client->data)->ref++
+
+#define sirinet_pipe_decref(client) \
+    if (!--((sirinet_pipe_t *) client->data)->ref) \
+        uv_close((uv_handle_t *) client, (uv_close_cb) sirinet__pipe_free)

--- a/siridb.conf
+++ b/siridb.conf
@@ -60,7 +60,17 @@ heartbeat_interval = 30
 max_open_files = 32768
 
 #
-# Use shard compression for storing data points. 
+# Use shard compression for storing data points.
 # Set value 0 to disable shard compression.
 #
 enable_shard_compression = 1
+
+#
+# Enable named pipe support for client connections.
+#
+enable_pipe_support = 0
+
+#
+# SiriDB will bind the client named pipe in this location.
+#
+pipe_client_name = siridb_client.sock

--- a/src/siri/cfg/cfg.c
+++ b/src/siri/cfg/cfg.c
@@ -29,7 +29,9 @@ static siri_cfg_t siri_cfg = {
         .ip_support=IP_SUPPORT_ALL,
         .shard_compression=0,
         .server_address="localhost",
-        .default_db_path="/var/lib/siridb/"
+        .default_db_path="/var/lib/siridb/",
+        .pipe_support=0,
+        .pipe_client_name="siridb_client.sock"
 };
 
 static void SIRI_CFG_read_uint(
@@ -47,10 +49,15 @@ static void SIRI_CFG_read_addr(
         cfgparser_t * cfgparser,
         const char * option_name,
         char ** dest);
+static void SIRI_CFG_read_pipe_name(
+        cfgparser_t * cfgparser,
+        const char * option_name,
+        char * dest);
 static void SIRI_CFG_read_default_db_path(cfgparser_t * cfgparser);
 static void SIRI_CFG_read_max_open_files(cfgparser_t * cfgparser);
 static void SIRI_CFG_read_ip_support(cfgparser_t * cfgparser);
 static void SIRI_CFG_read_shard_compression(cfgparser_t * cfgparser);
+static void SIRI_CFG_read_pipe_support(cfgparser_t * cfgparser);
 
 void siri_cfg_init(siri_t * siri)
 {
@@ -118,6 +125,16 @@ void siri_cfg_init(siri_t * siri)
             cfgparser,
             "bind_server_address",
             &siri_cfg.bind_backend_addr);
+
+    SIRI_CFG_read_pipe_support(cfgparser);
+
+    if (siri_cfg.pipe_support)
+    {
+        SIRI_CFG_read_pipe_name(
+                cfgparser,
+                "pipe_client_name",
+                &siri_cfg.pipe_client_name);
+    }
 
     cfgparser_free(cfgparser);
 }
@@ -273,6 +290,40 @@ static void SIRI_CFG_read_shard_compression(cfgparser_t * cfgparser)
 
 }
 
+static void SIRI_CFG_read_pipe_support(cfgparser_t * cfgparser)
+{
+    cfgparser_option_t * option;
+    cfgparser_return_t rc;
+    rc = cfgparser_get_option(
+                &option,
+                cfgparser,
+                "siridb",
+                "enable_pipe_support");
+    if (rc != CFGPARSER_SUCCESS)
+    {
+        log_debug(
+                "Missing '%s' in '%s': %s. "
+                "Disable pipe support",
+                "enable_pipe_support",
+                siri.args->config,
+                cfgparser_errmsg(rc));
+    }
+    else if (option->tp != CFGPARSER_TP_INTEGER || option->val->integer > 1)
+    {
+        log_warning(
+                "Error reading '%s' in '%s': %s. "
+                "Disable pipe support",
+                "enable_pipe_support",
+                siri.args->config,
+                "error: expecting 0 or 1");
+    }
+    else if (option->val->integer == 1)
+    {
+        siri_cfg.pipe_support = 1;
+    }
+
+}
+
 static void SIRI_CFG_read_addr(
         cfgparser_t * cfgparser,
         const char * option_name,
@@ -314,6 +365,62 @@ static void SIRI_CFG_read_addr(
     if (!(*dest))
     {
         log_error("Error allocating memory for address.");
+    }
+}
+
+static void SIRI_CFG_read_pipe_name(
+        cfgparser_t * cfgparser,
+        const char * option_name,
+        char * dest)
+{
+    cfgparser_option_t * option;
+    cfgparser_return_t rc;
+    size_t len;
+    rc = cfgparser_get_option(
+                &option,
+                cfgparser,
+                "siridb",
+                option_name);
+    if (rc != CFGPARSER_SUCCESS)
+    {
+        log_warning(
+                "Error reading '%s' in '%s': %s. "
+                "Using default value: '%s'",
+                option_name,
+                siri.args->config,
+                cfgparser_errmsg(rc),
+                dest);
+    }
+    else if (option->tp != CFGPARSER_TP_STRING)
+    {
+        log_warning(
+                "Error reading '%s' in '%s': %s. "
+                "Using default value: '%s'",
+                option_name,
+                siri.args->config,
+                "error: expecting a string value",
+                dest);
+    }
+    else
+    {
+        *dest = 0;
+
+        /* keep space left for a terminator char */
+        strncpy(dest,
+                option->val->string,
+                SIRI_PATH_MAX - 1);
+
+        len = strlen(dest);
+
+        if (len == SIRI_PATH_MAX - 1)
+        {
+            log_warning(
+                    "Default '%s' path exceeds %d characters, please "
+                    "check your configuration file: %s",
+                    option_name,
+                    SIRI_PATH_MAX - 2,
+                    siri.args->config);
+        }
     }
 }
 

--- a/src/siri/db/auth.c
+++ b/src/siri/db/auth.c
@@ -58,8 +58,18 @@ cproto_server_t siridb_auth_user_request(
         return CPROTO_ERR_AUTH_CREDENTIALS;
     }
 
-    ((sirinet_socket_t *) client->data)->siridb = siridb;
-    ((sirinet_socket_t *) client->data)->origin = user;
+    switch (client->type)
+    {
+    case UV_TCP:
+        ((sirinet_socket_t *) client->data)->siridb = siridb;
+        ((sirinet_socket_t *) client->data)->origin = user;
+        break;
+    case UV_NAMED_PIPE:
+        ((sirinet_pipe_t *) client->data)->siridb = siridb;
+        ((sirinet_pipe_t *) client->data)->origin = user;
+        break;
+    }
+
     siridb_user_incref(user);
 
     return CPROTO_RES_AUTH_SUCCESS;
@@ -116,8 +126,17 @@ bproto_server_t siridb_auth_server_request(
         return BPROTO_AUTH_ERR_UNKNOWN_UUID;
     }
 
-    ((sirinet_socket_t *) client->data)->siridb = siridb;
-    ((sirinet_socket_t *) client->data)->origin = server;
+    switch (client->type)
+    {
+    case UV_TCP:
+        ((sirinet_socket_t *) client->data)->siridb = siridb;
+        ((sirinet_socket_t *) client->data)->origin = server;
+        break;
+    case UV_NAMED_PIPE:
+        ((sirinet_pipe_t *) client->data)->siridb = siridb;
+        ((sirinet_pipe_t *) client->data)->origin = server;
+        break;
+    }
 
     free(server->version);
     server->version = strdup((const char *) qp_version->via.raw);
@@ -127,4 +146,3 @@ bproto_server_t siridb_auth_server_request(
 
     return BPROTO_AUTH_SUCCESS;
 }
-

--- a/src/siri/net/bserver.c
+++ b/src/siri/net/bserver.c
@@ -764,4 +764,3 @@ static void on_disable_backup_mode(uv_stream_t * client, sirinet_pkg_t * pkg)
         sirinet_pkg_send(client, package);
     }
 }
-

--- a/src/siri/net/pipe.c
+++ b/src/siri/net/pipe.c
@@ -1,0 +1,245 @@
+#include <assert.h>
+#include <logger/logger.h>
+#include <siri/admin/client.h>
+#include <siri/err.h>
+#include <siri/net/protocol.h>
+#include <siri/net/pipe.h>
+#include <siri/siri.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_ALLOWED_PKG_SIZE 20971520      /* 20 MB  */
+
+#define QUIT_PIPE                     \
+    free(spipe->buf);                 \
+    spipe->buf = NULL;                \
+    spipe->len = 0;                   \
+    spipe->size = 0;                  \
+    spipe->on_data = NULL;            \
+    sirinet_pipe_decref(client);      \
+    return;
+
+/*
+ * This function can raise a SIGNAL.
+ */
+void sirinet_pipe_alloc_buffer(
+        uv_handle_t * handle,
+        size_t suggested_size,
+        uv_buf_t * buf)
+{
+    sirinet_pipe_t * spipe = (sirinet_pipe_t *) handle->data;
+
+    if (!spipe->len && spipe->size > RESET_BUF_SIZE)
+    {
+        free(spipe->buf);
+        spipe->buf = (char *) malloc(suggested_size);
+        if (spipe->buf == NULL)
+        {
+            ERR_ALLOC
+            buf->len = 0;
+            return;
+        }
+        spipe->size = suggested_size;
+        spipe->len = 0;
+    }
+    buf->base = spipe->buf + spipe->len;
+    buf->len = spipe->size - spipe->len;
+}
+
+/*
+ * Buffer should have a size of PIPE_NAME_SZ
+ *
+ * Return 0 if successful or -1 in case of an error.
+ */
+int sirinet_pipe_name(char * buffer, uv_stream_t * client)
+{
+    size_t len = PIPE_NAME_SZ - 1;
+
+    if (uv_pipe_getsockname(
+            (uv_pipe_t *) client,
+            buffer,
+            &len))
+    {
+        return -1;
+    }
+
+    buffer[len] = 0;
+    return 0;
+}
+
+/*
+ * This function can raise a SIGNAL.
+ */
+void sirinet_pipe_on_data(
+        uv_stream_t * client,
+        ssize_t nread,
+        const uv_buf_t * buf)
+{
+    sirinet_pipe_t * spipe = (sirinet_pipe_t *) client->data;
+    sirinet_pkg_t * pkg;
+    size_t total_sz;
+    uint8_t check;
+
+    /*
+     * spipe->on_data is NULL when 'sirinet_pipe_decref' is called from
+     * within this function. We should never call 'sirinet_pipe_decref' twice
+     * so the best thing is to log and and exit this function.
+     */
+    if (spipe->on_data == NULL)
+    {
+        char pipe_name[PIPE_NAME_SZ];
+        if (sirinet_pipe_name(pipe_name, client) == 0)
+        {
+            log_error(
+                    "Received data from '%s' but we ignore the data since the "
+                    "connection will be closed in a few seconds...",
+                pipe_name);
+        }
+        return;
+    }
+
+    if (nread < 0)
+    {
+        if (nread != UV_EOF)
+        {
+            log_error("Read error: %s", uv_err_name(nread));
+        }
+        QUIT_PIPE
+    }
+
+    spipe->len += nread;
+
+    if (spipe->len < sizeof(sirinet_pkg_t))
+    {
+        return;
+    }
+
+    pkg = (sirinet_pkg_t *) spipe->buf;
+    check = pkg->tp ^ 255;
+    if (    check != pkg->checkbit ||
+            (spipe->tp == PIPE_CLIENT && pkg->len > MAX_ALLOWED_PKG_SIZE))
+    {
+        char pipe_name[PIPE_NAME_SZ];
+        if (sirinet_pipe_name(pipe_name, client) == 0)
+        {
+            log_error(
+                "Got an illegal package or size too large from '%s', "
+                "closing connection "
+                "(pid: %" PRIu16 ", len: %" PRIu32 ", tp: %" PRIu8 ")",
+                pipe_name, pkg->pid, pkg->len, pkg->tp);
+        }
+        QUIT_PIPE
+    }
+
+    total_sz = sizeof(sirinet_pkg_t) + pkg->len;
+    if (spipe->len < total_sz)
+    {
+        if (spipe->size < total_sz)
+        {
+            char * tmp = realloc(spipe->buf, total_sz);
+            if (tmp == NULL)
+            {
+                log_critical(
+                    "Cannot allocate size for package "
+                    "(pid: %" PRIu16 ", len: %" PRIu32 ", tp: %" PRIu8 ")",
+                    pkg->pid, pkg->len, pkg->tp);
+                QUIT_PIPE
+            }
+            spipe->buf = tmp;
+            spipe->size = total_sz;
+        }
+        return;
+    }
+
+    /* call on-data function */
+    (*spipe->on_data)(client, pkg);
+
+    spipe->len -= total_sz;
+
+    if (spipe->len > 0)
+    {
+        /* move data and call sirinet_pipe_on_data() function again */
+        memmove(spipe->buf, spipe->buf + total_sz, spipe->len);
+        sirinet_pipe_on_data(client, 0, buf);
+    }
+}
+
+/*
+ * Returns NULL and raises a SIGNAL in case an error has occurred.
+ *
+ * Note: ((sirinet_pipe_t *) pipe->data)->ref is initially set to 1
+ */
+uv_pipe_t * sirinet_pipe_new(
+        sirinet_pipe_tp_t tp,
+        on_data_cb_t cb_data,
+        on_free_cb_t cb_free)
+{
+    sirinet_pipe_t * spipe =
+            (sirinet_pipe_t *) malloc(sizeof(sirinet_pipe_t));
+
+    if (spipe == NULL)
+    {
+        ERR_ALLOC
+        return NULL;
+    }
+
+    spipe->tp = tp;
+    spipe->on_data = cb_data;
+    spipe->on_free = cb_free;
+    spipe->buf = NULL;
+    spipe->len = 0;
+    spipe->size = -1; /* this will force allocating on first request */
+    spipe->origin = NULL;
+    spipe->siridb = NULL;
+    spipe->ref = 1;
+    spipe->pipe.data = spipe;
+
+    return &spipe->pipe;
+}
+
+/*
+ * Never use this function but call sirinet_pipe_decref.
+ * Destroy pipe. (parsing NULL is not allowed)
+ *
+ * We know three different pipe types:
+ *  - client: used for clients. a user object might be destroyed.
+ *  - back-end: used to connect to other servers. a server might be destroyed.
+ *  - server: user for severs connecting to here. a server might be destroyed.
+ *
+ *  In case a server is destroyed, remaining promises will be cancelled and
+ *  the call-back functions will be called.
+ */
+void sirinet__pipe_free(uv_stream_t * client)
+{
+    sirinet_pipe_t * spipe = client->data;
+
+#if DEBUG
+    log_debug("Free pipe type: %d", spipe->tp);
+#endif
+
+    switch (spipe->tp)
+    {
+    case PIPE_CLIENT:  /* listens to client connections  */
+        if (spipe->origin != NULL)
+        {
+            siridb_user_t * user = (siridb_user_t *) spipe->origin;
+            siridb_user_decref(user);
+        }
+        break;
+    case PIPE_BACKEND:  /* listens to server connections  */
+        if (spipe->origin != NULL)
+        {
+            siridb_server_t * server = (siridb_server_t *) spipe->origin;
+            siridb_server_decref(server);
+        }
+        break;
+    }
+
+    if (spipe->on_free != NULL)
+    {
+        spipe->on_free(client);
+    }
+
+    free(spipe->buf);
+    free(spipe);
+}

--- a/src/siri/net/pkg.c
+++ b/src/siri/net/pkg.c
@@ -13,7 +13,7 @@
 #include <logger/logger.h>
 #include <siri/err.h>
 #include <siri/net/pkg.h>
-#include <siri/net/socket.h>
+#include <siri/net/clserver.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -167,7 +167,7 @@ int sirinet_pkg_send(uv_stream_t * client, sirinet_pkg_t * pkg)
     }
 
     /* increment client reference counter */
-    sirinet_socket_incref(client);
+    sirinet_client_incref(client);
 
     data->client = client;
     data->pkg = pkg;
@@ -213,7 +213,7 @@ static void PKG_write_cb(uv_write_t * req, int status)
 
     pkg_send_t * data = (pkg_send_t *) req->data;
 
-    sirinet_socket_decref(data->client);
+    sirinet_client_decref(data->client);
 
     free(data->pkg);
     free(data);

--- a/src/siri/siri.c
+++ b/src/siri/siri.c
@@ -40,6 +40,7 @@
 #include <siri/help/help.h>
 #include <siri/net/bserver.h>
 #include <siri/net/clserver.h>
+#include <siri/net/pipe.h>
 #include <siri/net/socket.h>
 #include <siri/parser/listener.h>
 #include <siri/siri.h>
@@ -491,8 +492,6 @@ static void SIRI_walk_close_handlers(
 
     switch (handle->type)
     {
-    case UV_WORK:
-        break;
     case UV_SIGNAL:
         /* this is where we cleanup the signal handlers */
         uv_close(handle, NULL);
@@ -509,6 +508,20 @@ static void SIRI_walk_close_handlers(
         else
         {
             sirinet_socket_decref(handle);
+        }
+        break;
+
+    case UV_NAMED_PIPE:
+        /* This can be a pipe server with data set to NULL or a SiriDB pipe
+         * which should be destroyed.
+         */
+        if (handle->data == NULL)
+        {
+            uv_close(handle, NULL);
+        }
+        else
+        {
+            sirinet_pipe_decref(handle);
         }
         break;
 


### PR DESCRIPTION
Support pipes via `uv_pipe_t`. They should be significantly faster than TCP loopback: https://stackoverflow.com/questions/14973942/tcp-loopback-connection-vs-unix-domain-socket-performance

This is still WIP and needs testing. I've only tested connection/disconnection to SiriDB via pipe on Linux (ARM).