### PR TITLE
Make ref counting atomic

### DIFF
--- a/include/siri/db/series.h
+++ b/include/siri/db/series.h
@@ -128,14 +128,14 @@ void siridb_series_ensure_type(siridb_series_t * series, qp_obj_t * qp_obj);
 /*
  * Increment the series reference counter.
  */
-#define siridb_series_incref(series) series->ref++
+#define siridb_series_incref(series) __atomic_add_fetch(&(series)->ref, 1, __ATOMIC_SEQ_CST)
 
 /*
  * Decrement reference counter for series and free the series when zero is
  * reached.
  */
 #define siridb_series_decref(series__) \
-        if (!--series__->ref) siridb__series_free(series__)
+        if (!__atomic_sub_fetch(&(series__)->ref, 1, __ATOMIC_SEQ_CST)) siridb__series_free(series__)
 
 
 #define siridb_series_server_id(series) \

--- a/include/siri/db/shard.h
+++ b/include/siri/db/shard.h
@@ -162,7 +162,7 @@ static inline siridb_shard_get_points_cb siridb_shard_get_points_callback(
 /*
  * Increment the shard reference counter.
  */
-#define siridb_shard_incref(shard) shard->ref++
+#define siridb_shard_incref(shard) __atomic_add_fetch(&(shard)->ref, 1, __ATOMIC_SEQ_CST)
 
 /*
  * Decrement the reference counter, when 0 the shard will be destroyed.
@@ -173,7 +173,7 @@ static inline siridb_shard_get_points_cb siridb_shard_get_points_callback(
  * A signal can be raised in case closing the shard file fails.
  */
 #define siridb_shard_decref(shard__)     \
-        if (!--shard__->ref) siridb__shard_free(shard__)
+        if (!__atomic_sub_fetch(&(shard__)->ref, 1, __ATOMIC_SEQ_CST)) siridb__shard_free(shard__)
 
 
 #define siridb_shard_idx_file(Name__, Fn__)         \

--- a/include/vec/vec.h
+++ b/include/vec/vec.h
@@ -24,7 +24,7 @@ int vec_append_safe(vec_t ** vec, void * data);
  * Expects the object to have a object->ref (uint_xxx_t) on top of the
  * objects definition.
  */
-#define vec_object_incref(object) ((vec_object_t * ) object)->ref++
+#define vec_object_incref(object) __atomic_add_fetch(&((vec_object_t * ) (object))->ref, 1, __ATOMIC_SEQ_CST)
 
 /*
  * Expects the object to have a object->ref (uint_xxx_t) on top of the
@@ -34,7 +34,7 @@ int vec_append_safe(vec_t ** vec, void * data);
  *          there are still references left on the object since an object
  *          probably needs specific cleanup tasks.
  */
-#define vec_object_decref(object) ((vec_object_t * ) object)->ref--
+#define vec_object_decref(object) __atomic_sub_fetch(&((vec_object_t * ) (object))->ref, 1, __ATOMIC_SEQ_CST)
 
 /*
  * Append data to the list. This functions assumes the list can hold the new


### PR DESCRIPTION
The ref counter on shards and series is accessed on multiple threads and should be atomic.

Still WIP. 