### PR TITLE
Shards cannot been loaded correctly in ARM build

### DIFF
--- a/include/siri/db/shard.h
+++ b/include/siri/db/shard.h
@@ -128,7 +128,7 @@ struct siridb_shard_s
     uint64_t id;
     size_t len;         /* size of the shard which is used */
     size_t size;        /* size of shard on disk */
-    size_t duration;    /* based on the interval of series */
+    uint64_t duration;    /* based on the interval of series */
     siri_fp_t * fp;
     char * fn;
     siridb_shard_t * replacing;


### PR DESCRIPTION
The duration will be cast from uint64_t and cause the shards file name been generated incorrectly when reloading database's shard files.