### PR TITLE
Fixed siridb_time_now returns incorrect number in arm32 build

### DIFF
--- a/src/siri/db/query.c
+++ b/src/siri/db/query.c
@@ -896,7 +896,7 @@ static int QUERY_time_expr(
                     *size,
                     "%" PRIu64,
                         siridb_time_parse(node->str, node->len) *
-                        walker->siridb->time->factor);
+                        (uint64_t)walker->siridb->time->factor);
             if (n >= (ssize_t) *size)
             {
                 return EXPR_TOO_LONG;
@@ -930,7 +930,7 @@ static int QUERY_time_expr(
                     buf + EXPR_MAX_SIZE - *size,
                     *size,
                     "%" PRId64,
-                    ts * walker->siridb->time->factor);
+                    ts * (uint64_t)walker->siridb->time->factor);
 
             if (n >= (ssize_t) *size)
             {

--- a/src/siri/db/time.c
+++ b/src/siri/db/time.c
@@ -60,6 +60,6 @@ uint32_t siridb_time_in_seconds(siridb_t * siridb, int64_t ts)
 
 uint64_t siridb_time_now(siridb_t * siridb, struct timespec now)
 {
-    return now.tv_sec * siridb->time->factor +
-        now.tv_nsec * (siridb->time->factor / 1000000000.0);
+    return now.tv_sec * (uint64_t)siridb->time->factor +
+        now.tv_nsec * ((uint64_t)siridb->time->factor / 1000000000.0);
 }


### PR DESCRIPTION
We had siridb-server in our ARM device which Cortex-A7, and the siridb_time_now returns incorrect number. 

if time.tv_sec is 1614844851 and time.tv_nsec is 490840489, with factor 1000, the siridb_time_now returns 4232115490.

The ARM device is running OpenWRT with musl


