### PR TITLE
fix arm32 build by using uint64_t as factor

### DIFF
--- a/include/siri/db/time.h
+++ b/include/siri/db/time.h
@@ -23,14 +23,14 @@ typedef struct siridb_time_s siridb_time_t;
 
 static const char * SIRIDB_TIME_SHORT_MAP[SIRIDB_TIME_END] = {"s", "ms", "us", "ns"};
 siridb_time_t * siridb_time_new(siridb_timep_t precision);
-uint32_t siridb_time_in_seconds(siridb_t * siridb, int64_t ts);
+uint64_t siridb_time_in_seconds(siridb_t * siridb, int64_t ts);
 uint64_t siridb_time_now(siridb_t * siridb, struct timespec now);
 uint64_t siridb_time_parse(const char * str, size_t len);
 
 struct siridb_time_s
 {
     siridb_timep_t precision;
-    uint32_t factor;
+    uint64_t factor;
     size_t ts_sz;
 };
 

--- a/include/siri/version.h
+++ b/include/siri/version.h
@@ -15,7 +15,7 @@
  * Note that debian alpha packages should use versions like this:
  *   2.0.34-0alpha0
  */
-#define SIRIDB_VERSION_PRE_RELEASE "-alpha-0"
+#define SIRIDB_VERSION_PRE_RELEASE "-alpha-1"
 
 #ifndef NDEBUG
 #define SIRIDB_VERSION_BUILD_RELEASE "+debug"

--- a/src/siri/db/time.c
+++ b/src/siri/db/time.c
@@ -24,7 +24,7 @@ siridb_time_t * siridb_time_new(siridb_timep_t precision)
     else
     {
         time->precision = precision;
-        time->factor = xmath_ipow(1000, precision);
+        time->factor = (uint64_t) xmath_ipow(1000, precision);
         time->ts_sz = (precision == SIRIDB_TIME_SECONDS) ?
                 sizeof(uint32_t) : sizeof(uint64_t);
     }
@@ -53,7 +53,7 @@ uint64_t siridb_time_parse(const char * str, size_t len)
     return 0;
 }
 
-uint32_t siridb_time_in_seconds(siridb_t * siridb, int64_t ts)
+uint64_t siridb_time_in_seconds(siridb_t * siridb, int64_t ts)
 {
     return ts / siridb->time->factor;
 }


### PR DESCRIPTION
Alternative solution for arm32 fix, see #169 