### PR TITLE
Add ignore_broken_data config option

### DIFF
--- a/include/siri/cfg/cfg.h
+++ b/include/siri/cfg/cfg.h
@@ -45,6 +45,8 @@ struct siri_cfg_s
     char server_address[SIRI_CFG_MAX_LEN_ADDRESS];
     char db_path[XPATH_MAX];
     char pipe_client_name[XPATH_MAX];
+
+    uint8_t ignore_broken_data;
 };
 
 #endif  /* SIRI_CFG_H_ */

--- a/siridb.conf
+++ b/siridb.conf
@@ -63,7 +63,7 @@ buffer_sync_interval = 0
 
 #
 # SiriDB will not open more shard files than max_open_files. Note that the
-# total number of open files can be sligtly higher since SiriDB also needs
+# total number of open files can be slightly higher since SiriDB also needs
 # a few other files to write to.
 #
 max_open_files = 32768
@@ -80,6 +80,15 @@ enable_shard_compression = 1
 # is not able to detect a sensible duration.
 #
 enable_shard_auto_duration = 1
+
+#
+# SiriDB will ignore corrupted or broken shards and related database files even
+# at the cost of losing some or all data.
+#
+# This option is useful especially for transient data on systems prone to power
+# outage or frequent hard resets.
+#
+ignore_broken_data = 0
 
 #
 # Enable named pipe support for client connections.

--- a/src/siri/cfg/cfg.c
+++ b/src/siri/cfg/cfg.c
@@ -32,6 +32,7 @@ static siri_cfg_t siri_cfg = {
         .pipe_support=0,
         .pipe_client_name="siridb_client.sock",
         .buffer_sync_interval=0,
+        .ignore_broken_data=0
 };
 
 static void SIRI_CFG_read_uint(
@@ -56,6 +57,7 @@ static void SIRI_CFG_read_ip_support(cfgparser_t * cfgparser);
 static void SIRI_CFG_read_shard_compression(cfgparser_t * cfgparser);
 static void SIRI_CFG_read_shard_auto_duration(cfgparser_t * cfgparser);
 static void SIRI_CFG_read_pipe_support(cfgparser_t * cfgparser);
+static void SIRI_CFG_ignore_broken_data(cfgparser_t * cfgparser);
 
 void siri_cfg_init(siri_t * siri)
 {
@@ -159,6 +161,8 @@ void siri_cfg_init(siri_t * siri)
             300000,
             &tmp);
     siri_cfg.buffer_sync_interval = (uint32_t) tmp;
+
+    SIRI_CFG_ignore_broken_data(cfgparser);
 
     cfgparser_free(cfgparser);
 }
@@ -351,6 +355,32 @@ static void SIRI_CFG_read_pipe_support(cfgparser_t * cfgparser)
     else if (option->val->integer == 1)
     {
         siri_cfg.pipe_support = 1;
+    }
+}
+
+static void SIRI_CFG_ignore_broken_data(cfgparser_t * cfgparser)
+{
+    cfgparser_option_t * option;
+    cfgparser_return_t rc;
+    rc = cfgparser_get_option(
+        &option,
+        cfgparser,
+        "siridb",
+        "ignore_broken_data");
+    if (rc != CFGPARSER_SUCCESS)
+    {
+        return; // optional config option
+    }
+    else if (option->tp != CFGPARSER_TP_INTEGER || option->val->integer > 1)
+    {
+        log_warning(
+            "Error reading 'ignore_broken_data' in '%s': %s.",
+            siri.args->config,
+            "error: expecting 0 or 1");
+    }
+    else if (option->val->integer == 1)
+    {
+        siri_cfg.ignore_broken_data = 1;
     }
 }
 


### PR DESCRIPTION
The option will cause SiriDB to ignore broken or corrupted data that would otherwise prevent the server or database from fully loading.

This is useful for transient data on systems prone to hard resets, which might leave the database in an inconsistent state.

We run into problems where customers with on-premise deployments get errors about broken shards or the existence of a temporary buffer file. While it's valid to stop loading the database to prevent further data loss, it's completely acceptable to lose some or all data for our use case.

I understand this might not be a generally useful feature. In that case, feel free to close the PR.