### PR TITLE
Add head and tail syntax

### DIFF
--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -56,9 +56,9 @@ class SiriGrammar(Grammar):
     k_as = Keyword('as')
     k_backup_mode = Keyword('backup_mode')
     k_before = Keyword('before')
-    k_buffer_size = Keyword('buffer_size')
-    k_buffer_path = Keyword('buffer_path')
     k_between = Keyword('between')
+    k_buffer_path = Keyword('buffer_path')
+    k_buffer_size = Keyword('buffer_size')
     k_count = Keyword('count')
     k_create = Keyword('create')
     k_critical = Keyword('critical')
@@ -88,6 +88,7 @@ class SiriGrammar(Grammar):
     k_grant = Keyword('grant')
     k_group = Keyword('group')
     k_groups = Keyword('groups')
+    k_head = Keyword('head')
     k_help = Choice(Keyword('help'), Token('?'))
     k_idle_percentage = Keyword('idle_percentage')
     k_idle_time = Keyword('idle_time')
@@ -165,6 +166,7 @@ class SiriGrammar(Grammar):
     k_sync_progress = Keyword('sync_progress')
     k_tag = Keyword('tag')
     k_tags = Keyword('tags')
+    k_tail = Keyword('tail')
     k_tee = Keyword('tee')
     k_time_precision = Keyword('time_precision')
     k_timeit = Keyword('timeit')
@@ -465,6 +467,8 @@ class SiriGrammar(Grammar):
     before_expr = Sequence(k_before, time_expr)
     after_expr = Sequence(k_after, time_expr)
     between_expr = Sequence(k_between, time_expr, k_and, time_expr)
+    head_expr = Sequence(k_head, int_expr)
+    tail_expr = Sequence(k_tail, int_expr)
     access_expr = List(access_keywords, ',', 1)
 
     prefix_expr = Sequence(k_prefix, string)
@@ -816,6 +820,8 @@ class SiriGrammar(Grammar):
             after_expr,
             between_expr,
             before_expr,
+            tail_expr,
+            head_expr,
             most_greedy=False)),
         Optional(merge_as))
 

--- a/include/siri/db/points.h
+++ b/include/siri/db/points.h
@@ -25,6 +25,8 @@ void siridb_points_init(void);
 siridb_points_t * siridb_points_new(size_t size, points_tp tp);
 void siridb_points_free(siridb_points_t * points);
 int siridb_points_resize(siridb_points_t * points, size_t n);
+void siridb_points_tail(siridb_points_t * points, size_t n);
+void siridb_points_head(siridb_points_t * points, size_t n);
 void siridb_points_add_point(
         siridb_points_t *__restrict points,
         uint64_t * ts,

--- a/include/siri/db/queries.h
+++ b/include/siri/db/queries.h
@@ -129,6 +129,7 @@ struct query_select_s
     QUERY_DEF
     size_t n;
     size_t nselects;
+    ssize_t headtail;       /* negative is tail, positive is head */
     uint64_t * start_ts;    /* will NOT be freed        */
     uint64_t * end_ts;      /* will NOT be freed        */
     siridb_presuf_t * presuf;

--- a/include/siri/db/series.h
+++ b/include/siri/db/series.h
@@ -100,6 +100,12 @@ siridb_points_t * siridb_series_get_points(
         siridb_series_t *__restrict series,
         uint64_t *__restrict start_ts,
         uint64_t *__restrict end_ts);
+siridb_points_t * siridb_series_get_points_tail(
+        siridb_series_t *__restrict series,
+        size_t tail);
+siridb_points_t * siridb_series_get_points_head(
+        siridb_series_t *__restrict series,
+        size_t head);
 void siridb_series_remove_shard(
         siridb_t *__restrict siridb,
         siridb_series_t *__restrict series,

--- a/include/siri/grammar/grammar.h
+++ b/include/siri/grammar/grammar.h
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: SiriGrammar
- * Created at: 2022-04-15 12:10:03
+ * Created at: 2022-05-05 15:08:05
  */
 #ifndef CLERI_EXPORT_SIRI_GRAMMAR_GRAMMAR_H_
 #define CLERI_EXPORT_SIRI_GRAMMAR_GRAMMAR_H_
@@ -81,6 +81,7 @@ enum cleri_grammar_ids {
     CLERI_GID_GROUP_COLUMNS,
     CLERI_GID_GROUP_NAME,
     CLERI_GID_GROUP_TAG_MATCH,
+    CLERI_GID_HEAD_EXPR,
     CLERI_GID_HELP_ACCESS,
     CLERI_GID_HELP_ALTER,
     CLERI_GID_HELP_ALTER_DATABASE,
@@ -165,6 +166,7 @@ enum cleri_grammar_ids {
     CLERI_GID_K_GRANT,
     CLERI_GID_K_GROUP,
     CLERI_GID_K_GROUPS,
+    CLERI_GID_K_HEAD,
     CLERI_GID_K_HELP,
     CLERI_GID_K_IDLE_PERCENTAGE,
     CLERI_GID_K_IDLE_TIME,
@@ -236,6 +238,7 @@ enum cleri_grammar_ids {
     CLERI_GID_K_SYNC_PROGRESS,
     CLERI_GID_K_TAG,
     CLERI_GID_K_TAGS,
+    CLERI_GID_K_TAIL,
     CLERI_GID_K_TEE,
     CLERI_GID_K_TIMEIT,
     CLERI_GID_K_TIMEVAL,
@@ -318,6 +321,7 @@ enum cleri_grammar_ids {
     CLERI_GID_TAG_COLUMNS,
     CLERI_GID_TAG_NAME,
     CLERI_GID_TAG_SERIES,
+    CLERI_GID_TAIL_EXPR,
     CLERI_GID_TIMEIT_STMT,
     CLERI_GID_TIME_EXPR,
     CLERI_GID_UNTAG_SERIES,

--- a/include/siri/siri.h
+++ b/include/siri/siri.h
@@ -18,6 +18,7 @@
 
 #define SIRI_MAX_SIZE_ERR_MSG 1024
 #define MAX_NUMBER_DB 1024
+#define MAX_HEADTAIL 1000000L
 
 #if defined(__GLIBC__)
 #define strerror_si(__err, __buf, __sz) \

--- a/include/siri/version.h
+++ b/include/siri/version.h
@@ -6,7 +6,7 @@
 
 #define SIRIDB_VERSION_MAJOR 2
 #define SIRIDB_VERSION_MINOR 0
-#define SIRIDB_VERSION_PATCH 47
+#define SIRIDB_VERSION_PATCH 48
 
 /*
  * Use SIRIDB_VERSION_PRE_RELEASE for alpha release versions.
@@ -20,7 +20,7 @@
 #ifndef NDEBUG
 #define SIRIDB_VERSION_BUILD_RELEASE "+debug"
 #else
-#define SIRIDB_VERSION_BUILD_RELEASE ""
+#define SIRIDB_VERSION_BUILD_RELEASE "-alpha-0"
 #endif
 
 #define SIRIDB_STRINGIFY(num) #num

--- a/src/siri/db/listener.c
+++ b/src/siri/db/listener.c
@@ -1981,8 +1981,6 @@ static void exit_head_expr(uv_async_t * handle)
 
     ((query_select_t *) query->data)->headtail = head;
 
-    LOGC("Head: %zd", ((query_select_t *) query->data)->headtail);
-
     SIRIPARSER_NEXT_NODE
 }
 
@@ -2003,8 +2001,6 @@ static void exit_tail_expr(uv_async_t * handle)
     }
 
     ((query_select_t *) query->data)->headtail = -tail;
-
-    LOGC("Tail: %zd", ((query_select_t *) query->data)->headtail);
 
     SIRIPARSER_NEXT_NODE
 }

--- a/src/siri/db/listener.c
+++ b/src/siri/db/listener.c
@@ -1965,21 +1965,21 @@ static void exit_after_expr(uv_async_t * handle)
 static void exit_head_expr(uv_async_t * handle)
 {
     siridb_query_t * query = handle->data;
-    ssize_t head = *((ssize_t *) CLERI_NODE_DATA_ADDR(
-                cleri_gn(query->nodes->node->children->next)));
+    ssize_t * head = (ssize_t *) CLERI_NODE_DATA_ADDR(
+                cleri_gn(query->nodes->node->children->next));
 
 
-    if (head <= 0 || head > MAX_HEADTAIL)
+    if (*head <= 0 || *head > MAX_HEADTAIL)
     {
         snprintf(query->err_msg,
                 SIRIDB_MAX_SIZE_ERR_MSG,
                 "Head must be a value between 1 and %ld, got %zd",
-                MAX_HEADTAIL, head);
+                MAX_HEADTAIL, *head);
         siridb_query_send_error(handle, CPROTO_ERR_QUERY);
         return;
     }
 
-    ((query_select_t *) query->data)->headtail = head;
+    ((query_select_t *) query->data)->headtail = *head;
 
     SIRIPARSER_NEXT_NODE
 }
@@ -1987,20 +1987,20 @@ static void exit_head_expr(uv_async_t * handle)
 static void exit_tail_expr(uv_async_t * handle)
 {
     siridb_query_t * query = handle->data;
-    ssize_t tail = *((ssize_t *) CLERI_NODE_DATA_ADDR(
-                cleri_gn(query->nodes->node->children->next)));
+    ssize_t * tail = (ssize_t *) CLERI_NODE_DATA_ADDR(
+                cleri_gn(query->nodes->node->children->next));
 
-    if (tail < 1 || tail > MAX_HEADTAIL)
+    if (*tail < 1 || *tail > MAX_HEADTAIL)
     {
         snprintf(query->err_msg,
                 SIRIDB_MAX_SIZE_ERR_MSG,
                 "Tail must be a value between 1 and %ld, got %zd",
-                MAX_HEADTAIL, tail);
+                MAX_HEADTAIL, *tail);
         siridb_query_send_error(handle, CPROTO_ERR_QUERY);
         return;
     }
 
-    ((query_select_t *) query->data)->headtail = -tail;
+    ((query_select_t *) query->data)->headtail = -(*tail);
 
     SIRIPARSER_NEXT_NODE
 }

--- a/src/siri/db/points.c
+++ b/src/siri/db/points.c
@@ -103,6 +103,55 @@ int siridb_points_resize(siridb_points_t * points, size_t n)
 }
 
 /*
+ * Resize points to a new size. Returns 0 when successful or -1 if failed.
+ */
+void siridb_points_tail(siridb_points_t * points, size_t n)
+{
+    if (n < points->len)
+    {
+        size_t i;
+        siridb_point_t * point = points->data + (points->len - n);
+        if (points->tp == TP_STRING)
+        {
+            for (i = 0; i < n; ++i, ++point)
+            {
+                free((points->data + i)->val.str);
+                *(points->data + i) = *point;
+            }
+        }
+        else
+        {
+            for (i = 0; i < n; ++i, ++point)
+            {
+                *(points->data + i) = *point;
+            }
+        }
+        points->len = n;
+        (void) siridb_points_resize(points, n);
+    }
+}
+
+/*
+ * Resize points to a new size. Returns 0 when successful or -1 if failed.
+ */
+void siridb_points_head(siridb_points_t * points, size_t n)
+{
+    if (n < points->len)
+    {
+        if (points->tp == TP_STRING)
+        {
+            size_t i = n, m = points->len;
+            for (; i < m; ++i)
+            {
+                free((points->data + i)->val.str);
+            }
+        }
+        points->len = n;
+        (void) siridb_points_resize(points, n);
+    }
+}
+
+/*
  * Returns a copy of points or NULL in case of an error. NULL is also returned
  * if points is NULL.
  */

--- a/src/siri/db/queries.c
+++ b/src/siri/db/queries.c
@@ -68,7 +68,7 @@ static void QUERIES_free_merge_result(vec_t * plist);
 
 query_select_t * query_select_new(void)
 {
-    query_select_t * q_select = malloc(sizeof(query_select_t));
+    query_select_t * q_select = calloc(1, sizeof(query_select_t));
 
     if (q_select == NULL)
     {
@@ -77,15 +77,7 @@ query_select_t * query_select_new(void)
     QUERIES_NEW(q_select)
 
     q_select->tp = QUERIES_SELECT;
-    q_select->start_ts = NULL;
-    q_select->end_ts = NULL;
-    q_select->presuf = NULL;
-    q_select->merge_as = NULL;
-    q_select->n = 0;
     q_select->nselects = 1;  /* we have at least one select function  */
-    q_select->points_map = NULL;
-    q_select->alist = NULL;
-    q_select->mlist = NULL;
     q_select->result = ct_new();
 
     if (q_select->result == NULL)

--- a/src/siri/grammar/grammar.c
+++ b/src/siri/grammar/grammar.c
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: SiriGrammar
- * Created at: 2022-04-15 12:10:03
+ * Created at: 2022-05-05 15:08:05
  */
 
 #include "siri/grammar/grammar.h"
@@ -40,9 +40,9 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
     cleri_t * k_as = cleri_keyword(CLERI_GID_K_AS, "as", CLERI_CASE_SENSITIVE);
     cleri_t * k_backup_mode = cleri_keyword(CLERI_GID_K_BACKUP_MODE, "backup_mode", CLERI_CASE_SENSITIVE);
     cleri_t * k_before = cleri_keyword(CLERI_GID_K_BEFORE, "before", CLERI_CASE_SENSITIVE);
-    cleri_t * k_buffer_size = cleri_keyword(CLERI_GID_K_BUFFER_SIZE, "buffer_size", CLERI_CASE_SENSITIVE);
-    cleri_t * k_buffer_path = cleri_keyword(CLERI_GID_K_BUFFER_PATH, "buffer_path", CLERI_CASE_SENSITIVE);
     cleri_t * k_between = cleri_keyword(CLERI_GID_K_BETWEEN, "between", CLERI_CASE_SENSITIVE);
+    cleri_t * k_buffer_path = cleri_keyword(CLERI_GID_K_BUFFER_PATH, "buffer_path", CLERI_CASE_SENSITIVE);
+    cleri_t * k_buffer_size = cleri_keyword(CLERI_GID_K_BUFFER_SIZE, "buffer_size", CLERI_CASE_SENSITIVE);
     cleri_t * k_count = cleri_keyword(CLERI_GID_K_COUNT, "count", CLERI_CASE_SENSITIVE);
     cleri_t * k_create = cleri_keyword(CLERI_GID_K_CREATE, "create", CLERI_CASE_SENSITIVE);
     cleri_t * k_critical = cleri_keyword(CLERI_GID_K_CRITICAL, "critical", CLERI_CASE_SENSITIVE);
@@ -72,6 +72,7 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
     cleri_t * k_grant = cleri_keyword(CLERI_GID_K_GRANT, "grant", CLERI_CASE_SENSITIVE);
     cleri_t * k_group = cleri_keyword(CLERI_GID_K_GROUP, "group", CLERI_CASE_SENSITIVE);
     cleri_t * k_groups = cleri_keyword(CLERI_GID_K_GROUPS, "groups", CLERI_CASE_SENSITIVE);
+    cleri_t * k_head = cleri_keyword(CLERI_GID_K_HEAD, "head", CLERI_CASE_SENSITIVE);
     cleri_t * k_help = cleri_choice(
         CLERI_GID_K_HELP,
         CLERI_MOST_GREEDY,
@@ -166,6 +167,7 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
     cleri_t * k_sync_progress = cleri_keyword(CLERI_GID_K_SYNC_PROGRESS, "sync_progress", CLERI_CASE_SENSITIVE);
     cleri_t * k_tag = cleri_keyword(CLERI_GID_K_TAG, "tag", CLERI_CASE_SENSITIVE);
     cleri_t * k_tags = cleri_keyword(CLERI_GID_K_TAGS, "tags", CLERI_CASE_SENSITIVE);
+    cleri_t * k_tail = cleri_keyword(CLERI_GID_K_TAIL, "tail", CLERI_CASE_SENSITIVE);
     cleri_t * k_tee = cleri_keyword(CLERI_GID_K_TEE, "tee", CLERI_CASE_SENSITIVE);
     cleri_t * k_time_precision = cleri_keyword(CLERI_GID_K_TIME_PRECISION, "time_precision", CLERI_CASE_SENSITIVE);
     cleri_t * k_timeit = cleri_keyword(CLERI_GID_K_TIMEIT, "timeit", CLERI_CASE_SENSITIVE);
@@ -894,6 +896,18 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
         time_expr,
         k_and,
         time_expr
+    );
+    cleri_t * head_expr = cleri_sequence(
+        CLERI_GID_HEAD_EXPR,
+        2,
+        k_head,
+        int_expr
+    );
+    cleri_t * tail_expr = cleri_sequence(
+        CLERI_GID_TAIL_EXPR,
+        2,
+        k_tail,
+        int_expr
     );
     cleri_t * access_expr = cleri_list(CLERI_GID_ACCESS_EXPR, access_keywords, cleri_token(CLERI_NONE, ","), 1, 0, 0);
     cleri_t * prefix_expr = cleri_sequence(
@@ -1676,10 +1690,12 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
         cleri_optional(CLERI_NONE, cleri_choice(
             CLERI_NONE,
             CLERI_FIRST_MATCH,
-            3,
+            5,
             after_expr,
             between_expr,
-            before_expr
+            before_expr,
+            tail_expr,
+            head_expr
         )),
         cleri_optional(CLERI_NONE, merge_as)
     );


### PR DESCRIPTION
This pull request enables to use `head` and `tail` to get the first or last number of points from series.

Both `head` and `tail` are currently implemented where a query usually asks for the time range. This is done, instead of an aggregation function because otherwise it would encourage a user to get all data for series and then trow it away.

Example: (get the latest 10 points from my-series)

```
select * from 'my-series' tail 10
```

Note the at most 10 points will be returned. If the series has less than 10 points, simply all point will be returned.
  
