### PR TITLE
siri/db: add NULL check before calling siridb_tasks_dec

### DIFF
--- a/src/siri/db/query.c
+++ b/src/siri/db/query.c
@@ -156,7 +156,10 @@ void siridb_query_free(uv_handle_t * handle)
     siridb_t * siridb = query->client->siridb;
 
     /* decrement active tasks */
-    siridb_tasks_dec(siridb->tasks);
+    if (siridb != NULL)
+    {
+        siridb_tasks_dec(siridb->tasks);
+    }
 
     /* free query */
     free(query->q);


### PR DESCRIPTION
When built against libuv1 1.44.2, `siridb_query_free` may call
`siridb_tasks_dec` on a NULL `siridb`, causing a segfault. Add a NULL check on `siridb`
before calling `siridb_tasks_dec` to avoid this.

For more background, see the related [Debian bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1017748), and [Ubuntu autopkgtest failures](https://autopkgtest.ubuntu.com/results/autopkgtest-kinetic/kinetic/amd64/s/siridb-server/20220818_063717_90e4d@/log.gz).

When using gdb to take a closer look, this is what I found:

```
Thread 1 "siridb-server" received signal SIGSEGV, Segmentation fault.
siridb_query_free (handle=0x55d2a8de6bf0) at ../src/siri/db/query.c:159
159	../src/siri/db/query.c: No such file or directory.
(gdb) bt
#0  siridb_query_free (handle=0x55d2a8de6bf0) at ../src/siri/db/query.c:159
#1  0x00007ff439a4ab65 in uv__finish_close (handle=0x55d2a8de6bf0) at ./src/unix/core.c:319
#2  uv__run_closing_handles (loop=0x55d2a8dd6760) at ./src/unix/core.c:333
#3  uv_run (loop=0x55d2a8dd6760, mode=mode@entry=UV_RUN_DEFAULT) at ./src/unix/core.c:421
#4  0x000055d2a884f981 in siri_start () at ../src/siri/siri.c:342
#5  0x000055d2a8800deb in main (argc=<optimized out>, argv=<optimized out>) at ../main.c:76
```

I have not been able to figure out exactly what changed in libuv 1.44.2 that caused this, but this should be a safe change to make regardless.