### PR TITLE
Implement option for Offset

### DIFF
--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -126,6 +126,7 @@ class SiriGrammar(Grammar):
     k_ninf = Sequence('-', k_inf)
     k_now = Keyword('now')
     k_number = Keyword('number')
+    k_offset = Keyword('offset')
     k_online = Keyword('online')
     k_open_files = Keyword('open_files')
     k_or = Keyword('or')
@@ -527,6 +528,9 @@ class SiriGrammar(Grammar):
     f_last = Sequence(
         k_last,
         '(', Optional(time_expr), ')')
+    f_offset = Sequence(
+        k_offset,
+        '(', Optional(time_expr), ')')
     f_timeval = Sequence(
         k_timeval,
         '(', ')')
@@ -572,6 +576,7 @@ class SiriGrammar(Grammar):
 
     aggregate_functions = List(Choice(
         f_all,
+        f_offset,
         f_limit,
         f_mean,
         f_sum,

--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -530,7 +530,7 @@ class SiriGrammar(Grammar):
         '(', Optional(time_expr), ')')
     f_offset = Sequence(
         k_offset,
-        '(', Optional(time_expr), ')')
+        '(', time_expr, ')')
     f_timeval = Sequence(
         k_timeval,
         '(', ')')

--- a/include/siri/grammar/grammar.h
+++ b/include/siri/grammar/grammar.h
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: SiriGrammar
- * Created at: 2022-05-05 15:08:05
+ * Created at: 2023-10-24 14:29:56
  */
 #ifndef CLERI_EXPORT_SIRI_GRAMMAR_GRAMMAR_H_
 #define CLERI_EXPORT_SIRI_GRAMMAR_GRAMMAR_H_
@@ -70,6 +70,7 @@ enum cleri_grammar_ids {
     CLERI_GID_F_MEDIAN_HIGH,
     CLERI_GID_F_MEDIAN_LOW,
     CLERI_GID_F_MIN,
+    CLERI_GID_F_OFFSET,
     CLERI_GID_F_POINTS,
     CLERI_GID_F_PVARIANCE,
     CLERI_GID_F_STDDEV,
@@ -201,6 +202,7 @@ enum cleri_grammar_ids {
     CLERI_GID_K_NINF,
     CLERI_GID_K_NOW,
     CLERI_GID_K_NUMBER,
+    CLERI_GID_K_OFFSET,
     CLERI_GID_K_ONLINE,
     CLERI_GID_K_OPEN_FILES,
     CLERI_GID_K_OR,

--- a/include/siri/grammar/grammar.h
+++ b/include/siri/grammar/grammar.h
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: SiriGrammar
- * Created at: 2023-10-24 14:29:56
+ * Created at: 2023-10-24 15:46:26
  */
 #ifndef CLERI_EXPORT_SIRI_GRAMMAR_GRAMMAR_H_
 #define CLERI_EXPORT_SIRI_GRAMMAR_GRAMMAR_H_

--- a/include/siri/version.h
+++ b/include/siri/version.h
@@ -15,7 +15,7 @@
  * Note that debian alpha packages should use versions like this:
  *   2.0.34-0alpha0
  */
-#define SIRIDB_VERSION_PRE_RELEASE "-alpha-0"
+#define SIRIDB_VERSION_PRE_RELEASE "-alpha-1"
 
 #ifndef NDEBUG
 #define SIRIDB_VERSION_BUILD_RELEASE "+debug"

--- a/include/siri/version.h
+++ b/include/siri/version.h
@@ -15,7 +15,7 @@
  * Note that debian alpha packages should use versions like this:
  *   2.0.34-0alpha0
  */
-#define SIRIDB_VERSION_PRE_RELEASE "-alpha-1"
+#define SIRIDB_VERSION_PRE_RELEASE "-alpha-2"
 
 #ifndef NDEBUG
 #define SIRIDB_VERSION_BUILD_RELEASE "+debug"

--- a/include/siri/version.h
+++ b/include/siri/version.h
@@ -6,7 +6,7 @@
 
 #define SIRIDB_VERSION_MAJOR 2
 #define SIRIDB_VERSION_MINOR 0
-#define SIRIDB_VERSION_PATCH 50
+#define SIRIDB_VERSION_PATCH 51
 
 /*
  * Use SIRIDB_VERSION_PRE_RELEASE for alpha release versions.
@@ -15,7 +15,7 @@
  * Note that debian alpha packages should use versions like this:
  *   2.0.34-0alpha0
  */
-#define SIRIDB_VERSION_PRE_RELEASE ""
+#define SIRIDB_VERSION_PRE_RELEASE "-alpha-0"
 
 #ifndef NDEBUG
 #define SIRIDB_VERSION_BUILD_RELEASE "+debug"

--- a/src/siri/db/aggregate.c
+++ b/src/siri/db/aggregate.c
@@ -232,17 +232,11 @@ vec_t * siridb_aggregate_list(cleri_children_t * children, char * err_msg)
             if (cleri_gn(cleri_gn(children)->children)
                     ->children->next->next->next != NULL)
             {
-                /* result is always positive, checked earlier */
+                /* group_by is always > 0 */
                 aggr->offset = CLERI_NODE_DATA(
                         cleri_gn(cleri_gn(cleri_gn(cleri_gn(children)
-                        ->children)->children->next->next)->children));
-
-                if (aggr->offset >= aggr->group_by)
-                {
-                    sprintf(err_msg, "Offset too large.");
-                    siridb_aggregate_list_free(vec);
-                    return NULL;
-                }
+                        ->children)->children->next->next)->children)
+                       ) % aggr->group_by;
             }
             break;
         case CLERI_GID_F_LIMIT:

--- a/src/siri/db/aggregate.c
+++ b/src/siri/db/aggregate.c
@@ -229,15 +229,10 @@ vec_t * siridb_aggregate_list(cleri_children_t * children, char * err_msg)
                 siridb_aggregate_list_free(vec);
                 return NULL;
             }
-            if (cleri_gn(cleri_gn(children)->children)
-                    ->children->next->next->next != NULL)
-            {
                 /* group_by is always > 0 */
-                aggr->offset = CLERI_NODE_DATA(
-                        cleri_gn(cleri_gn(cleri_gn(cleri_gn(children)
-                        ->children)->children->next->next)->children)
-                       ) % aggr->group_by;
-            }
+            aggr->offset = CLERI_NODE_DATA(
+                    cleri_gn(cleri_gn(cleri_gn(children)
+                    ->children)->children->next->next)) % aggr->group_by;
             break;
         case CLERI_GID_F_LIMIT:
             AGGR_NEW

--- a/src/siri/grammar/grammar.c
+++ b/src/siri/grammar/grammar.c
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: SiriGrammar
- * Created at: 2022-05-05 15:08:05
+ * Created at: 2023-10-24 14:29:56
  */
 
 #include "siri/grammar/grammar.h"
@@ -124,6 +124,7 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
     );
     cleri_t * k_now = cleri_keyword(CLERI_GID_K_NOW, "now", CLERI_CASE_SENSITIVE);
     cleri_t * k_number = cleri_keyword(CLERI_GID_K_NUMBER, "number", CLERI_CASE_SENSITIVE);
+    cleri_t * k_offset = cleri_keyword(CLERI_GID_K_OFFSET, "offset", CLERI_CASE_SENSITIVE);
     cleri_t * k_online = cleri_keyword(CLERI_GID_K_ONLINE, "online", CLERI_CASE_SENSITIVE);
     cleri_t * k_open_files = cleri_keyword(CLERI_GID_K_OPEN_FILES, "open_files", CLERI_CASE_SENSITIVE);
     cleri_t * k_or = cleri_keyword(CLERI_GID_K_OR, "or", CLERI_CASE_SENSITIVE);
@@ -1050,6 +1051,14 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
         cleri_optional(CLERI_NONE, time_expr),
         cleri_token(CLERI_NONE, ")")
     );
+    cleri_t * f_offset = cleri_sequence(
+        CLERI_GID_F_OFFSET,
+        4,
+        k_offset,
+        cleri_token(CLERI_NONE, "("),
+        cleri_optional(CLERI_NONE, time_expr),
+        cleri_token(CLERI_NONE, ")")
+    );
     cleri_t * f_timeval = cleri_sequence(
         CLERI_GID_F_TIMEVAL,
         3,
@@ -1094,7 +1103,8 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
         cleri_choice(
             CLERI_NONE,
             CLERI_FIRST_MATCH,
-            13,
+            14,
+            k_offset,
             k_mean,
             k_median,
             k_median_high,
@@ -1114,8 +1124,9 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
     cleri_t * aggregate_functions = cleri_list(CLERI_GID_AGGREGATE_FUNCTIONS, cleri_choice(
         CLERI_NONE,
         CLERI_FIRST_MATCH,
-        21,
+        22,
         f_all,
+        f_offset,
         f_limit,
         f_mean,
         f_sum,

--- a/src/siri/grammar/grammar.c
+++ b/src/siri/grammar/grammar.c
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: SiriGrammar
- * Created at: 2023-10-24 14:29:56
+ * Created at: 2023-10-24 15:46:26
  */
 
 #include "siri/grammar/grammar.h"
@@ -1056,7 +1056,7 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
         4,
         k_offset,
         cleri_token(CLERI_NONE, "("),
-        cleri_optional(CLERI_NONE, time_expr),
+        time_expr,
         cleri_token(CLERI_NONE, ")")
     );
     cleri_t * f_timeval = cleri_sequence(
@@ -1103,8 +1103,7 @@ cleri_grammar_t * compile_siri_grammar_grammar(void)
         cleri_choice(
             CLERI_NONE,
             CLERI_FIRST_MATCH,
-            14,
-            k_offset,
+            13,
             k_mean,
             k_median,
             k_median_high,


### PR DESCRIPTION
Implement an option for defining an offset when using aggregation functions.

For example:

```
select mean(1d) => offset(2h) from ...
```

The above will take the mean per day, with an offset of 2 hours. (for example when using a timezone of +2h)

Note that when using the offset, the daylight saving times are not honored